### PR TITLE
Google Ads 1‑click integration: ad‑block safe functions, reliable ingest, MCC fallback, UI improvements

### DIFF
--- a/src/components/integrations/GoogleAdsIntegration.tsx
+++ b/src/components/integrations/GoogleAdsIntegration.tsx
@@ -251,7 +251,7 @@ export function GoogleAdsIntegration() {
       // Use últimos 7 dias como padrão
       const endDate = new Date();
       const startDate = new Date();
-      startDate.setDate(startDate.getDate() - 7);
+      startDate.setDate(startDate.getDate() - 30);
 
       const { data, error } = await invokeFunctionWithFallback(
         ['ga-ingest', 'google-ads-ingest'],

--- a/src/shared/data-source/adapters/supabase.ts
+++ b/src/shared/data-source/adapters/supabase.ts
@@ -256,12 +256,27 @@ export class SupabaseAdapter implements DataSource {
     };
   }
 
+  private normalizePlatform(p: string | null | undefined): 'google' | 'meta' | 'linkedin' | 'tiktok' | 'all' | any {
+    const v = (p || '').toLowerCase();
+    if (v === 'google_ads' || v === 'google') return 'google';
+    if (v === 'meta_ads' || v === 'meta') return 'meta';
+    return p as any;
+  }
+
+  private normalizeStatus(s: string | null | undefined): 'active' | 'paused' | 'draft' | 'ended' | any {
+    const v = (s || '').toUpperCase();
+    if (v === 'ENABLED' || v === 'ACTIVE') return 'active';
+    if (v === 'PAUSED') return 'paused';
+    if (v === 'REMOVED' || v === 'ENDED') return 'ended';
+    return s as any;
+  }
+
   private mapSupabaseMetric(row: any): MetricRow {
     return {
       date: row.date,
       clientId: row.client_id,
       campaignId: row.campaign_id,
-      platform: row.platform,
+      platform: this.normalizePlatform(row.platform),
       impressions: Number(row.impressions || 0),
       clicks: Number(row.clicks || 0),
       spend: Number(row.spend || 0),
@@ -279,9 +294,9 @@ export class SupabaseAdapter implements DataSource {
     return {
       id: row.id,
       clientId: row.client_id,
-      platform: row.platform,
+      platform: this.normalizePlatform(row.platform),
       name: row.name,
-      status: row.status,
+      status: this.normalizeStatus(row.status),
       objective: row.objective,
       lastSync: row.last_sync || new Date().toISOString()
     };

--- a/supabase/functions/ga-ingest/index.ts
+++ b/supabase/functions/ga-ingest/index.ts
@@ -2,364 +2,273 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-// Duplicate of google-ads-ingest with ad-blocker-safe name
-// Fetches metrics from Google Ads API and sends to ingest-metrics endpoint
+// Neutral-named duplicate of google-ads-ingest to avoid ad-blockers
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
 const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
-const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") || "";
-const AUTH_KEY = SERVICE_KEY || ANON_KEY;
+const GOOGLE_ADS_DEVELOPER_TOKEN = Deno.env.get("GOOGLE_ADS_DEVELOPER_TOKEN") || "";
 
-const DEV_TOKEN = Deno.env.get("GOOGLE_ADS_DEVELOPER_TOKEN") || "";
-const OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
-const ADS_API_BASE = "https://googleads.googleapis.com/v21";
-const METRICUS_INGEST_KEY = Deno.env.get("METRICUS_INGEST_KEY") || "";
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+} as const;
 
-function log(...args: any[]) {
-  console.log("[ga-ingest]", ...args);
+function log(...args: any[]) { 
+  console.log("[ga-ingest]", ...args); 
 }
 
 interface MetricData {
   date: string;
-  customer_id: string;
-  campaign_id?: string;
-  campaign_name?: string;
-  platform: string;
+  campaign_id: string;
+  campaign_name: string;
+  campaign_status?: string;
   impressions: number;
   clicks: number;
-  spend: number;
+  cost: number;
   conversions: number;
-  revenue?: number;
 }
 
-async function getValidAccessTokenAndMcc(userId: string, companyId?: string) {
-  if (!SUPABASE_URL || !AUTH_KEY) throw new Error("supabase_env_missing");
+async function getValidAccessTokenAndMcc(userId: string, companyId?: string): Promise<{ accessToken: string, loginCustomerId: string }> {
+  const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
+  const { data: tokens, error } = await supabase
+    .from('google_tokens')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (error || !tokens || tokens.length === 0) {
+    throw new Error('No Google Ads tokens found');
+  }
+  const token = tokens[0];
 
-  const url = new URL(`${SUPABASE_URL}/rest/v1/google_tokens`);
-  url.searchParams.set("select", "id,refresh_token,access_token,token_expiry,login_customer_id");
-  url.searchParams.set("order", "created_at.desc");
-  url.searchParams.set("limit", "1");
-  url.searchParams.set("user_id", `eq.${userId}`);
+  const FORCED_MCC = Deno.env.get("FORCED_MCC_LOGIN_ID");
+  const mccToUse = FORCED_MCC || '2478435835';
+  const sanitizedMcc = mccToUse.replace(/-/g, '');
 
-  const resp = await fetch(url.toString(), {
-    headers: { apikey: AUTH_KEY, Authorization: `Bearer ${AUTH_KEY}` },
-  });
-
-  if (!resp.ok) throw new Error(`db_select ${resp.status}: ${await resp.text()}`);
-  const rows = await resp.json();
-  if (!rows?.length || !rows[0]?.refresh_token) throw new Error("no_refresh_token_found");
-
-  const token = rows[0];
-  const expiry = token.token_expiry ? new Date(token.token_expiry).getTime() : 0;
-  const now = Date.now();
-
+  const now = new Date();
+  const expiry = new Date(token.token_expiry);
   let accessToken = token.access_token;
 
-  if (!accessToken || expiry <= now + 60000) {
-    log("Refreshing expired token...");
-    const client_id = Deno.env.get("GOOGLE_OAUTH_CLIENT_ID") || "";
-    const client_secret = Deno.env.get("GOOGLE_OAUTH_CLIENT_SECRET") || "";
-    if (!client_id || !client_secret) throw new Error("oauth_client_missing");
-
-    const body = new URLSearchParams({
-      grant_type: "refresh_token",
-      refresh_token: token.refresh_token,
-      client_id,
-      client_secret,
-    });
-
-    const r = await fetch(OAUTH_TOKEN_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body,
-    });
-    const t = await r.text();
-    let j: any;
-    try {
-      j = JSON.parse(t);
-    } catch {
-      j = { raw: t };
+  if (now >= expiry) {
+    log('Token expired, refreshing...');
+    const CLIENT_ID = Deno.env.get("GOOGLE_OAUTH_CLIENT_ID");
+    const CLIENT_SECRET = Deno.env.get("GOOGLE_OAUTH_CLIENT_SECRET");
+    if (!CLIENT_ID || !CLIENT_SECRET) {
+      throw new Error('Missing OAuth credentials for token refresh');
     }
-    if (!r.ok) throw new Error(`refresh_error ${r.status}: ${JSON.stringify(j)}`);
-    accessToken = j.access_token as string;
-
-    const newExpiry = new Date(now + (j.expires_in || 3600) * 1000).toISOString();
-    const updateUrl = new URL(`${SUPABASE_URL}/rest/v1/google_tokens`);
-    updateUrl.searchParams.set("id", `eq.${token.id}`);
-
-    await fetch(updateUrl.toString(), {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        apikey: SERVICE_KEY,
-        Authorization: `Bearer ${SERVICE_KEY}`,
-      },
-      body: JSON.stringify({ access_token: accessToken, token_expiry: newExpiry }),
+    const refreshResponse = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: token.refresh_token,
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+      }),
     });
-
-    log("Token refreshed successfully");
+    if (!refreshResponse.ok) {
+      const errorText = await refreshResponse.text();
+      log('Token refresh failed:', refreshResponse.status, errorText);
+      throw new Error('Failed to refresh Google Ads token');
+    }
+    const refreshData = await refreshResponse.json();
+    accessToken = refreshData.access_token;
+    const newExpiry = new Date();
+    newExpiry.setSeconds(newExpiry.getSeconds() + (refreshData.expires_in || 3600));
+    await supabase
+      .from('google_tokens')
+      .update({
+        access_token: accessToken,
+        token_expiry: newExpiry.toISOString(),
+        updated_at: new Date().toISOString()
+      })
+      .eq('user_id', userId);
+    log('Token refreshed successfully');
   }
-
-  let loginCustomerId = token.login_customer_id || Deno.env.get("FORCED_MCC_LOGIN_ID") || null;
-
-  if (loginCustomerId) {
-    loginCustomerId = loginCustomerId.replace(/-/g, "");
-  }
-
-  return { accessToken, loginCustomerId };
+  return { accessToken, loginCustomerId: sanitizedMcc };
 }
 
-async function validateHierarchy(accessToken: string, targetCustomerId: string, loginCustomerId: string) {
-  if (!DEV_TOKEN) throw new Error("dev_token_missing");
-
-  const sanitizedTarget = targetCustomerId.replace(/-/g, "");
-  const sanitizedMcc = loginCustomerId.replace(/-/g, "");
-
-  log(`Validating hierarchy: MCC ${sanitizedMcc} manages target ${sanitizedTarget}...`);
-
+async function validateHierarchy(accessToken: string, targetCustomerId: string, loginCustomerId: string): Promise<void> {
+  const cleanMcc = loginCustomerId.replace(/-/g, '');
   const query = `
-    SELECT 
-      customer_client.client_customer,
-      customer_client.descriptive_name,
-      customer_client.manager,
-      customer_client.level
+    SELECT customer_client.id
     FROM customer_client
-    WHERE customer_client.level <= 1
+    WHERE customer_client.id = ${targetCustomerId}
+    LIMIT 1
   `;
-
   const headers = {
-    Authorization: `Bearer ${accessToken}`,
-    "developer-token": DEV_TOKEN,
-    "login-customer-id": sanitizedMcc,
-    "Content-Type": "application/json",
+    'Authorization': `Bearer ${accessToken}`,
+    'developer-token': GOOGLE_ADS_DEVELOPER_TOKEN,
+    'login-customer-id': cleanMcc,
+    'Content-Type': 'application/json',
   };
-
-  const response = await fetch(`${ADS_API_BASE}/customers/${sanitizedMcc}/googleAds:search`, {
-    method: "POST",
+  log(`[ads-call] { endpoint: "customerClient", urlCustomerId: "${cleanMcc}", targetCustomerId: "${targetCustomerId}", loginCustomerId: "${cleanMcc}" }`);
+  const response = await fetch(`https://googleads.googleapis.com/v21/customers/${cleanMcc}/googleAds:search`, {
+    method: 'POST',
     headers,
-    body: JSON.stringify({ query }),
+    body: JSON.stringify({ query })
   });
-
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`MCC hierarchy validation failed (${response.status}): ${errorText}`);
+    throw new Error(`Hierarchy validation failed: O MCC ${cleanMcc} não gerencia a conta ${targetCustomerId}. Conecte a conta certa ou altere o MCC/dev-token.`);
   }
-
-  const result = await response.json();
-  const childIds = (result.results || [])
-    .map((row: any) => row.customerClient?.clientCustomer?.replace("customers/", ""))
-    .filter(Boolean);
-
-  log(`MCC ${sanitizedMcc} manages ${childIds.length} child accounts`);
-
-  if (!childIds.includes(sanitizedTarget)) {
-    throw new Error(`MCC ${sanitizedMcc} does not manage target account ${sanitizedTarget}`);
+  const data = await response.json();
+  if (!data.results || data.results.length === 0) {
+    throw new Error(`O MCC ${cleanMcc} não gerencia a conta ${targetCustomerId}. Conecte a conta certa ou altere o MCC/dev-token.`);
   }
-
-  log(`✓ Hierarchy validated: MCC manages target account`);
 }
 
-async function runGoogleAdsQuery(
-  accessToken: string,
-  customerId: string,
-  query: string,
-  loginCustomerId?: string
-): Promise<MetricData[]> {
-  if (!DEV_TOKEN) throw new Error("dev_token_missing");
-
-  const sanitizedCustomerId = customerId.replace(/-/g, "");
+async function runGoogleAdsQuery(accessToken: string, customerId: string, query: string, loginCustomerId?: string): Promise<MetricData[]> {
+  const cleanCustomerId = customerId.replace(/-/g, '');
+  log(`[ads-call] { endpoint: "googleAds:searchStream", urlCustomerId: "${cleanCustomerId}", targetCustomerId: "${cleanCustomerId}", loginCustomerId: "${loginCustomerId || 'none'}" }`);
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${accessToken}`,
-    "developer-token": DEV_TOKEN,
-    "Content-Type": "application/json",
+    'Authorization': `Bearer ${accessToken}`,
+    'developer-token': GOOGLE_ADS_DEVELOPER_TOKEN,
+    'Content-Type': 'application/json',
   };
-
-  if (loginCustomerId) {
-    const sanitizedMcc = loginCustomerId.replace(/-/g, "");
-    headers["login-customer-id"] = sanitizedMcc;
-    log(`Using login-customer-id: ${sanitizedMcc}`);
-  } else {
-    log("No login-customer-id header (fallback mode)");
-  }
-
-  const logHeaders = { ...headers };
-  logHeaders.Authorization = "Bearer [REDACTED]";
-  log(`Query headers:`, logHeaders);
-
-  const response = await fetch(`${ADS_API_BASE}/customers/${sanitizedCustomerId}/googleAds:searchStream`, {
-    method: "POST",
+  if (loginCustomerId) headers['login-customer-id'] = loginCustomerId;
+  const response = await fetch(`https://googleads.googleapis.com/v21/customers/${cleanCustomerId}/googleAds:searchStream`, {
+    method: 'POST',
     headers,
-    body: JSON.stringify({ query }),
+    body: JSON.stringify({ query })
   });
-
+  log('Google Ads API response status:', response.status);
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Google Ads API error (${response.status}): ${errorText}`);
+    log('Google Ads API error:', response.status, errorText);
+    if (response.status === 403 && errorText.includes('USER_PERMISSION_DENIED')) {
+      const mccInfo = loginCustomerId ? ` MCC ${loginCustomerId}` : ' (sem MCC)';
+      throw new Error(`Acesso negado à conta ${cleanCustomerId}. Verifique se o${mccInfo} gerencia esta conta e se o developer token está aprovado.`);
+    }
+    throw new Error(`Google Ads API error: ${response.status} - ${errorText}`);
   }
-
   const payload = await response.json();
   const streams = Array.isArray(payload) ? payload : [payload];
-
   const metrics: MetricData[] = [];
-
   for (const stream of streams) {
-    if (!stream.results) continue;
-
-    for (const row of stream.results) {
-      const seg = row.segments || {};
-      const met = row.metrics || {};
-      const camp = row.campaign || {};
-
+    const rows = stream.results || [];
+    for (const row of rows) {
+      const segments = row.segments || {};
+      const campaign = row.campaign || {};
+      const m = row.metrics || {};
       metrics.push({
-        date: seg.date || "",
-        customer_id: sanitizedCustomerId,
-        campaign_id: camp.id || undefined,
-        campaign_name: camp.name || undefined,
-        platform: "google_ads",
-        impressions: parseInt(met.impressions || "0", 10),
-        clicks: parseInt(met.clicks || "0", 10),
-        spend: parseFloat(met.cost_micros || "0") / 1_000_000,
-        conversions: parseFloat(met.conversions || "0"),
-        revenue: parseFloat(met.conversions_value || "0"),
+        date: segments.date || new Date().toISOString().split('T')[0],
+        campaign_id: String(campaign.id ?? 'unknown'),
+        campaign_name: String(campaign.name ?? 'Unknown Campaign'),
+        campaign_status: String(campaign.status ?? 'ENABLED'),
+        impressions: Number(m.impressions ?? 0),
+        clicks: Number(m.clicks ?? 0),
+        cost: Number(m.cost_micros ?? 0) / 1_000_000,
+        conversions: Number(m.conversions ?? 0),
       });
     }
   }
-
+  log(`Successfully processed ${metrics.length} metric records`);
   return metrics;
 }
 
-async function sendToIngestEndpoint(metrics: MetricData[], customerId: string) {
-  if (!SUPABASE_URL || !METRICUS_INGEST_KEY) {
-    throw new Error("SUPABASE_URL or METRICUS_INGEST_KEY missing");
+async function sendToIngestEndpoint(metrics: MetricData[], customerId: string): Promise<any> {
+  const METRICUS_INGEST_KEY = Deno.env.get("METRICUS_INGEST_KEY");
+  if (!METRICUS_INGEST_KEY) {
+    const errorMsg = 'Configure METRICUS_INGEST_KEY nas envs das Functions.';
+    log('ERROR:', errorMsg);
+    throw new Error(errorMsg);
   }
-
-  const payload = metrics.map((m) => ({
-    date: m.date,
+  const transformedMetrics = metrics.map(metric => ({
+    date: metric.date,
     client_id: customerId,
-    customer_id: m.customer_id,
-    campaign_id: m.campaign_id,
-    platform: "google_ads",
-    impressions: m.impressions,
-    clicks: m.clicks,
-    spend: m.spend,
-    conversions: m.conversions,
-    revenue: m.revenue || 0,
-    leads: m.conversions,
+    customer_id: customerId,
+    platform: 'google_ads',
+    campaign_id: metric.campaign_id,
+    impressions: metric.impressions,
+    clicks: metric.clicks,
+    spend: metric.cost,
+    conversions: metric.conversions,
+    leads: metric.conversions,
+    cpa: metric.conversions > 0 ? metric.cost / metric.conversions : null,
+    ctr: metric.impressions > 0 ? (metric.clicks / metric.impressions) * 100 : null,
+    conv_rate: metric.clicks > 0 ? (metric.conversions / metric.clicks) * 100 : null,
   }));
-
-  log(`Sending ${payload.length} metrics to ingest-metrics endpoint...`);
-
+  log(`Sending ${transformedMetrics.length} metrics to ingest-metrics with x-api-key`);
   const ingestUrl = `${SUPABASE_URL}/functions/v1/ingest-metrics`;
   const response = await fetch(ingestUrl, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": METRICUS_INGEST_KEY,
-    },
-    body: JSON.stringify(payload),
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-api-key': METRICUS_INGEST_KEY },
+    body: JSON.stringify(transformedMetrics)
   });
-
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`ingest-metrics error (${response.status}): ${errorText}`);
+    log('Ingest endpoint error:', response.status, errorText);
+    if (response.status === 401) {
+      throw new Error('Configure METRICUS_INGEST_KEY nas envs das Functions.');
+    }
+    throw new Error(`Ingest error: ${response.status} - ${errorText}`);
   }
-
-  const result = await response.json();
-  log(`Metrics ingested successfully:`, result);
-  return result;
+  const data = await response.json();
+  log('Ingest successful:', data);
+  return data;
 }
 
-async function sendCampaignsToIngest(campaigns: any[], customerId: string) {
-  if (!SUPABASE_URL || !METRICUS_INGEST_KEY) {
-    throw new Error("SUPABASE_URL or METRICUS_INGEST_KEY missing");
-  }
-
-  log(`Sending ${campaigns.length} campaigns to ingest-campaigns endpoint...`);
-
+async function sendCampaignsToIngest(campaigns: Array<{ external_id: string; client_id: string; platform: 'google_ads'; name: string; status: 'ENABLED'|'PAUSED'|'REMOVED'; objective?: string | null; }>): Promise<any> {
+  const METRICUS_INGEST_KEY = Deno.env.get("METRICUS_INGEST_KEY");
+  if (!METRICUS_INGEST_KEY) throw new Error('Configure METRICUS_INGEST_KEY nas envs das Functions.');
   const ingestUrl = `${SUPABASE_URL}/functions/v1/ingest-campaigns`;
-  const response = await fetch(ingestUrl, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": METRICUS_INGEST_KEY,
-    },
+  const res = await fetch(ingestUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-api-key': METRICUS_INGEST_KEY },
     body: JSON.stringify(campaigns),
   });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`ingest-campaigns error (${response.status}): ${errorText}`);
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(`Ingest campaigns error: ${res.status} - ${txt}`);
   }
-
-  const result = await response.json();
-  log(`Campaigns ingested successfully:`, result);
-  return result;
+  return res.json();
 }
 
 serve(async (req) => {
-  const corsHeaders = {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  } as const;
-
-  if (req.method === "OPTIONS") {
+  if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
-
   try {
-    const body = await req.json();
-    const { user_id, company_id, customer_id, start_date, end_date } = body;
-
-    if (!user_id || !customer_id || !start_date || !end_date) {
-      throw new Error("Missing required parameters: user_id, customer_id, start_date, end_date");
-    }
-
-    log(`Starting ingestion for customer ${customer_id} from ${start_date} to ${end_date}`);
+    if (!SUPABASE_URL || !SERVICE_KEY) throw new Error("Missing Supabase environment variables");
+    if (!GOOGLE_ADS_DEVELOPER_TOKEN) throw new Error("Missing Google Ads Developer Token");
 
     const supabase = createClient(SUPABASE_URL, SERVICE_KEY);
+    const body = await req.json();
+    const { user_id, company_id, customer_id, start_date, end_date, allow_fallback_no_mcc } = body;
+    if (!user_id || !customer_id) throw new Error("Missing required parameters: user_id, customer_id");
 
-    const { data: ingestionRecord, error: insertError } = await supabase
-      .from("google_ads_ingestions")
-      .insert({
-        user_id,
-        company_id: company_id || null,
-        customer_id: customer_id.replace(/-/g, ""),
-        status: "in_progress",
-        start_date,
-        end_date,
-      })
+    const endDate = end_date || new Date().toISOString().split('T')[0];
+    const startDate = start_date || new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+
+    log('Starting ingestion', { user_id, customer_id, startDate, endDate });
+
+    const { data: ingestion, error: ingestionError } = await supabase
+      .from('google_ads_ingestions')
+      .insert({ user_id, customer_id, start_date: startDate, end_date: endDate, status: 'running' })
       .select()
       .single();
-
-    if (insertError || !ingestionRecord) {
-      throw new Error(`Failed to create ingestion record: ${insertError?.message}`);
-    }
-
-    const ingestionId = ingestionRecord.id;
-    log(`Created ingestion record: ${ingestionId}`);
+    if (ingestionError) throw new Error(`Failed to create ingestion record: ${ingestionError.message}`);
 
     try {
       const { accessToken, loginCustomerId } = await getValidAccessTokenAndMcc(user_id, company_id);
+      log(`Access token and MCC obtained. MCC: ***${loginCustomerId.slice(-4)}`);
 
-      const allowFallbackNoMcc = Deno.env.get("ALLOW_FALLBACK_NO_MCC") === "true";
-      let useMcc = loginCustomerId;
-      let hierarchyValid = false;
+      const envAllow = (Deno.env.get('ALLOW_FALLBACK_NO_MCC') || 'true').toLowerCase() === 'true';
+      const allowFallback = allow_fallback_no_mcc === true ? true : envAllow;
 
-      if (useMcc) {
-        try {
-          await validateHierarchy(accessToken, customer_id, useMcc);
-          hierarchyValid = true;
-        } catch (hierarchyError) {
-          log(`Hierarchy validation failed: ${hierarchyError}`);
-          if (allowFallbackNoMcc) {
-            log("Fallback enabled: will attempt without login-customer-id");
-            useMcc = null;
-          } else {
-            throw hierarchyError;
-          }
+      let shouldUseFallback = false;
+      try {
+        await validateHierarchy(accessToken, customer_id, loginCustomerId);
+        log(`Hierarchy validated for customer ${customer_id} with MCC ***${loginCustomerId.slice(-4)}`);
+      } catch (hierarchyError) {
+        log('Hierarchy validation failed:', hierarchyError);
+        if (allowFallback) {
+          shouldUseFallback = true;
+          log('FALLBACK: proceeding without login-customer-id header to query directly at child account');
+        } else {
+          throw hierarchyError;
         }
-      } else {
-        log("No MCC configured, proceeding without login-customer-id");
       }
 
       const query = `
@@ -371,85 +280,80 @@ serve(async (req) => {
           metrics.impressions,
           metrics.clicks,
           metrics.cost_micros,
-          metrics.conversions,
-          metrics.conversions_value
-        FROM campaign
-        WHERE segments.date BETWEEN '${start_date}' AND '${end_date}'
+          metrics.conversions
+        FROM campaign 
+        WHERE segments.date BETWEEN '${startDate}' AND '${endDate}'
         ORDER BY segments.date DESC
       `;
 
-      log(`Fetching metrics from Google Ads API...`);
-      const metrics = await runGoogleAdsQuery(accessToken, customer_id, query, useMcc || undefined);
-      log(`Fetched ${metrics.length} metric rows from Google Ads API`);
-
-      if (metrics.length === 0) {
-        log("No metrics found for the specified period");
+      if (shouldUseFallback) {
+        log(`Running query in FALLBACK mode (no login-customer-id) for account ${customer_id}`);
       }
+      const metrics = await runGoogleAdsQuery(accessToken, customer_id, query, shouldUseFallback ? undefined : loginCustomerId);
+      log(`Query executed successfully. Total results: ${metrics.length}`);
 
-      const ingestResult = await sendToIngestEndpoint(metrics, customer_id);
-      log(`Metrics ingestion result:`, ingestResult);
-
-      const uniqueCampaigns = new Map();
-      for (const m of metrics) {
-        if (m.campaign_id && !uniqueCampaigns.has(m.campaign_id)) {
-          uniqueCampaigns.set(m.campaign_id, {
-            id: `google_ads_${customer_id}_${m.campaign_id}`,
-            external_id: m.campaign_id,
-            client_id: customer_id,
-            platform: "google_ads",
-            name: m.campaign_name || `Campaign ${m.campaign_id}`,
-            status: "ENABLED",
-          });
+      if (metrics.length > 0) {
+        const ingestResult = await sendToIngestEndpoint(metrics, customer_id);
+        log('Ingest completed', ingestResult);
+        try {
+          const sanitizedCustomer = customer_id.replace(/-/g, '');
+          const { data: connection } = await supabase
+            .from('google_ads_connections')
+            .select('client_id')
+            .eq('customer_id', sanitizedCustomer)
+            .maybeSingle();
+          const linkedClientId: string | undefined = connection?.client_id;
+          if (linkedClientId) {
+            const statusMap = (s: string): 'ENABLED'|'PAUSED'|'REMOVED' => {
+              const up = (s || '').toUpperCase();
+              if (up.includes('PAUS')) return 'PAUSED';
+              if (up.includes('REMOV')) return 'REMOVED';
+              return 'ENABLED';
+            };
+            const unique = new Map<string, { external_id: string; client_id: string; platform: 'google_ads'; name: string; status: 'ENABLED'|'PAUSED'|'REMOVED'; objective?: string | null; }>();
+            for (const m of metrics) {
+              const key = m.campaign_id;
+              if (!unique.has(key)) {
+                unique.set(key, {
+                  external_id: m.campaign_id,
+                  client_id: linkedClientId,
+                  platform: 'google_ads',
+                  name: m.campaign_name,
+                  status: statusMap(m.campaign_status || 'ENABLED'),
+                  objective: null,
+                });
+              }
+            }
+            const campaignsPayload = Array.from(unique.values());
+            if (campaignsPayload.length > 0) {
+              log(`Upserting ${campaignsPayload.length} campaigns for client ${linkedClientId}`);
+              await sendCampaignsToIngest(campaignsPayload);
+              log('Campaigns ingest completed');
+            }
+          } else {
+            log('No client linkage found for customer; skipping campaign upsert');
+          }
+        } catch (e) {
+          log('Campaigns upsert skipped/failed:', e);
         }
       }
 
-      const campaignsArray = Array.from(uniqueCampaigns.values());
-      if (campaignsArray.length > 0) {
-        const campaignsResult = await sendCampaignsToIngest(campaignsArray, customer_id);
-        log(`Campaigns ingestion result:`, campaignsResult);
-      }
-
       await supabase
-        .from("google_ads_ingestions")
-        .update({
-          status: "completed",
-          records_ingested: metrics.length,
-          completed_at: new Date().toISOString(),
-        })
-        .eq("id", ingestionId);
+        .from('google_ads_ingestions')
+        .update({ status: 'completed', completed_at: new Date().toISOString(), records_processed: metrics.length })
+        .eq('id', ingestion.id);
 
-      log(`Ingestion completed successfully: ${metrics.length} records, ${campaignsArray.length} campaigns`);
-
-      return new Response(
-        JSON.stringify({
-          ok: true,
-          ingestion_id: ingestionId,
-          metrics_count: metrics.length,
-          campaigns_count: campaignsArray.length,
-          hierarchy_validated: hierarchyValid,
-          used_fallback: !useMcc && allowFallbackNoMcc,
-        }),
-        { headers: { "Content-Type": "application/json", ...corsHeaders } }
-      );
-    } catch (error) {
-      log(`Ingestion error:`, error);
-
+      return new Response(JSON.stringify({ ok: true, ingestion_id: ingestion.id, records_processed: metrics.length, customer_id, date_range: { start_date: startDate, end_date: endDate }, fallback_used: shouldUseFallback }), { headers: { "Content-Type": "application/json", ...corsHeaders } });
+    } catch (processingError) {
+      log('Processing error:', processingError);
       await supabase
-        .from("google_ads_ingestions")
-        .update({
-          status: "failed",
-          error_message: String(error),
-          completed_at: new Date().toISOString(),
-        })
-        .eq("id", ingestionId);
-
-      throw error;
+        .from('google_ads_ingestions')
+        .update({ status: 'failed', completed_at: new Date().toISOString(), error_message: processingError instanceof Error ? processingError.message : String(processingError) })
+        .eq('id', ingestion.id);
+      throw processingError;
     }
   } catch (e) {
     log("ingest_error", String(e));
-    return new Response(JSON.stringify({ ok: false, error: String(e) }), {
-      status: 400,
-      headers: { "Content-Type": "application/json", ...corsHeaders },
-    });
+    return new Response(JSON.stringify({ ok: false, error: String(e) }), { status: 400, headers: { "Content-Type": "application/json", ...corsHeaders } });
   }
 });

--- a/supabase/functions/ga-sync-accounts/index.ts
+++ b/supabase/functions/ga-sync-accounts/index.ts
@@ -2,9 +2,8 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-// Duplicate of google-ads-sync-accounts with ad-blocker-safe name
-// Reads refresh_token from current user → renews access_token → calls listAccessibleCustomers
-// → saves ALL customer_ids (without prefix) with details in accounts_map (upsert)
+// Neutral-named duplicate of google-ads-sync-accounts to avoid ad-blockers
+// Logic mirrors the original implementation
 
 const SUPABASE_URL  = Deno.env.get("SUPABASE_URL") || "";
 const SERVICE_KEY   = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
@@ -28,7 +27,7 @@ async function getLatestRefreshToken(user_id: string) {
   const resp = await fetch(url.toString(), {
     headers: { apikey: AUTH_KEY, Authorization: `Bearer ${AUTH_KEY}` },
   });
-  if (!resp.ok) throw new Error(`db_select ${resp.status}: ${await resp.text()}`);
+  if (!resp.ok) throw new Error(`db_select ${await resp.text()}`);
 
   const rows = await resp.json();
   if (!rows?.length || !rows[0]?.refresh_token) throw new Error("no_refresh_token_found_for_user");
@@ -78,14 +77,12 @@ async function listAccessibleCustomers(access_token: string) {
 
 async function getAccountDetails(access_token: string, customerIds: string[], loginCustomerId?: string | null) {
   if (!DEV_TOKEN) throw new Error("dev_token_missing");
-  
   const accountDetails: any[] = [];
   const baseHeaders: Record<string,string> = {
     'Authorization': `Bearer ${access_token}`,
     'developer-token': DEV_TOKEN,
     'Content-Type': 'application/json',
   };
-  
   if (loginCustomerId) {
     const sanitizedMccId = loginCustomerId.replace(/-/g, '');
     baseHeaders['login-customer-id'] = sanitizedMccId;
@@ -93,12 +90,10 @@ async function getAccountDetails(access_token: string, customerIds: string[], lo
   } else {
     log('WARNING: No login-customer-id provided - account names may be generic');
   }
-  
-  // Log headers for debugging (without exposing access token)
   const logHeaders = { ...baseHeaders };
   logHeaders.Authorization = 'Bearer [REDACTED]';
   log(`Account details request headers:`, logHeaders);
-  
+
   for (const customerId of customerIds) {
     try {
       const query = `
@@ -112,13 +107,11 @@ async function getAccountDetails(access_token: string, customerIds: string[], lo
         FROM customer 
         WHERE customer.id = ${customerId}
       `;
-      
       const response = await fetch(`${ADS_API_BASE}/customers/${customerId}/googleAds:searchStream`, {
         method: 'POST',
         headers: baseHeaders,
         body: JSON.stringify({ query })
       });
-      
       if (response.ok) {
         const payload = await response.json();
         const streams = Array.isArray(payload) ? payload : [payload];
@@ -127,11 +120,9 @@ async function getAccountDetails(access_token: string, customerIds: string[], lo
           const row = (stream.results || [])[0];
           if (row?.customer) { customerData = row.customer; break; }
         }
-        
         if (customerData) {
           const realName = customerData.descriptive_name;
           log(`Account ${customerId}: ${realName || 'no name'} (manager: ${Boolean(customerData.manager)})`);
-          
           accountDetails.push({
             customer_id: String(customerId),
             account_name: String(realName || `Account ${customerId}`),
@@ -154,13 +145,9 @@ async function getAccountDetails(access_token: string, customerIds: string[], lo
       } else {
         const errorText = await response.text();
         log(`Account ${customerId} query failed (${response.status}): ${errorText}`);
-        
-        // Check for specific permission errors
         if (response.status === 403 && errorText.includes('USER_PERMISSION_DENIED')) {
           log(`HINT: Account ${customerId} requires login-customer-id header (MCC parent account)`);
         }
-        
-        // Fallback se não conseguir buscar detalhes
         accountDetails.push({
           customer_id: String(customerId),
           account_name: `Account ${customerId}`,
@@ -172,7 +159,6 @@ async function getAccountDetails(access_token: string, customerIds: string[], lo
       }
     } catch (error) {
       log(`Error getting details for ${customerId}:`, error);
-      // Fallback
       accountDetails.push({
         customer_id: String(customerId),
         account_name: `Account ${customerId}`,
@@ -183,13 +169,11 @@ async function getAccountDetails(access_token: string, customerIds: string[], lo
       });
     }
   }
-  
   return accountDetails;
 }
 
 async function getMccChildAccounts(access_token: string, mccId: string) {
   if (!DEV_TOKEN) throw new Error("dev_token_missing");
-  
   const sanitizedMccId = mccId.replace(/-/g, '');
   const headers = {
     'Authorization': `Bearer ${access_token}`,
@@ -197,7 +181,6 @@ async function getMccChildAccounts(access_token: string, mccId: string) {
     'login-customer-id': sanitizedMccId,
     'Content-Type': 'application/json'
   };
-
   const query = `
     SELECT 
       customer_client.client_customer,
@@ -208,7 +191,6 @@ async function getMccChildAccounts(access_token: string, mccId: string) {
     FROM customer_client 
     WHERE customer_client.level <= 1
   `;
-
   try {
     log(`Searching MCC ${sanitizedMccId} for child accounts...`);
     const response = await fetch(`${ADS_API_BASE}/customers/${sanitizedMccId}/googleAds:search`, {
@@ -216,16 +198,13 @@ async function getMccChildAccounts(access_token: string, mccId: string) {
       headers,
       body: JSON.stringify({ query })
     });
-
     if (!response.ok) {
       const errorText = await response.text();
       log(`MCC child search failed (${response.status}): ${errorText}`);
       return [];
     }
-
     const result = await response.json();
     const childAccounts: any[] = [];
-
     if (result.results) {
       for (const row of result.results) {
         const client = row.customerClient;
@@ -243,7 +222,6 @@ async function getMccChildAccounts(access_token: string, mccId: string) {
         }
       }
     }
-
     return childAccounts;
   } catch (error) {
     log(`Error searching MCC child accounts: ${error}`);
@@ -254,16 +232,13 @@ async function getMccChildAccounts(access_token: string, mccId: string) {
 async function upsertCustomers(customerIds: string[], userId: string, access_token: string, loginCustomerId?: string | null) {
   if (!SUPABASE_URL || !SERVICE_KEY) throw new Error("service_role_required_for_upsert");
 
-  // Get detailed account information
   log(`Getting details for ${customerIds.length} accounts...`);
   let accountDetails = await getAccountDetails(access_token, customerIds, loginCustomerId);
-  
-  // Check if we have non-manager accounts with real names (not generic)
+
   const hasRealName = (n: any) => !!n && !String(n).startsWith('Account ');
   const nonManagerRealNamed = accountDetails.filter(account => !account.is_manager && hasRealName(account.account_name));
   log(`Non-manager accounts with real names: ${nonManagerRealNamed.length}`);
-  
-  // MCC expansion fallback if no real non-manager accounts found
+
   if (nonManagerRealNamed.length === 0) {
     const forcedMccId = Deno.env.get("FORCED_MCC_LOGIN_ID");
     if (forcedMccId) {
@@ -275,8 +250,7 @@ async function upsertCustomers(customerIds: string[], userId: string, access_tok
       }
     }
   }
-  
-  // De-duplicate by customer_id, prefer entries with real names
+
   const byId = new Map<string, any>();
   for (const acc of accountDetails) {
     const id = String(acc.customer_id || '');
@@ -288,13 +262,10 @@ async function upsertCustomers(customerIds: string[], userId: string, access_tok
     }
   }
   accountDetails = Array.from(byId.values());
-  
-  // Always use the provided MCC (2478435835)
+
   let detectedLoginCustomerId = loginCustomerId;
-  
   log(`Using login_customer_id: ${detectedLoginCustomerId || 'none'}`);
-  
-  // Save to accounts_map table with real account details
+
   const accountsData = accountDetails.map((account) => ({ 
     customer_id: String(account.customer_id || ''),
     client_id: String(account.customer_id || ''),
@@ -306,7 +277,6 @@ async function upsertCustomers(customerIds: string[], userId: string, access_tok
     status: String(account.status || 'ENABLED')
   }));
 
-  // Prepare data for google_ads_accounts table (UI source)
   const googleAdsAccountsData = accountDetails.map((account) => ({
     user_id: userId,
     customer_id: String(account.customer_id || ''),
@@ -321,7 +291,6 @@ async function upsertCustomers(customerIds: string[], userId: string, access_tok
   const mccAccounts = accountDetails.filter(account => account.is_manager);
   log(`MCC accounts found: ${mccAccounts.length}`);
 
-  // Upsert to accounts_map
   const upsertUrl = `${SUPABASE_URL}/rest/v1/accounts_map?on_conflict=customer_id`;
   const r = await fetch(upsertUrl, {
     method: "POST",
@@ -333,15 +302,24 @@ async function upsertCustomers(customerIds: string[], userId: string, access_tok
     },
     body: JSON.stringify(accountsData),
   });
-
   if (!r.ok && r.status !== 409) {
     const err = await r.text();
     throw new Error(`db_upsert_accounts_map ${r.status}: ${err}`);
   }
 
-  // Upsert to google_ads_accounts (UI source)
-  const upsertGoogleAdsUrl = `${SUPABASE_URL}/rest/v1/google_ads_accounts?on_conflict=user_id,customer_id`;
-  const r2 = await fetch(upsertGoogleAdsUrl, {
+  const uiRows = accountDetails.map((a) => ({
+    user_id: userId,
+    customer_id: String(a.customer_id || ''),
+    descriptive_name: String(a.account_name || `Account ${a.customer_id}`),
+    is_manager: Boolean(a.is_manager),
+    status: String(a.status || 'ENABLED'),
+    currency_code: a.currency_code || null,
+    time_zone: a.time_zone || null,
+    updated_at: new Date().toISOString(),
+  }));
+
+  const upsertUiUrl = `${SUPABASE_URL}/rest/v1/google_ads_accounts?on_conflict=user_id,customer_id`;
+  const r3 = await fetch(upsertUiUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -349,26 +327,21 @@ async function upsertCustomers(customerIds: string[], userId: string, access_tok
       Authorization: `Bearer ${SERVICE_KEY}`,
       Prefer: "resolution=merge-duplicates,return=representation",
     },
-    body: JSON.stringify(googleAdsAccountsData),
+    body: JSON.stringify(uiRows),
   });
-
-  if (!r2.ok && r2.status !== 409) {
-    const err = await r2.text();
-    throw new Error(`db_upsert_ui ${r2.status}: ${err}`);
+  if (!r3.ok && r3.status !== 409) {
+    const err2 = await r3.text();
+    throw new Error(`db_upsert_ui ${r3.status}: ${err2}`);
   }
 
-  // Always save the correct MCC in database (2478435835)
   if (customerIds.length > 0) {
     const updateUrl = new URL(`${SUPABASE_URL}/rest/v1/google_tokens`);
     updateUrl.searchParams.set("user_id", `eq.${userId}`);
-    
     const updateData = { 
       customer_id: customerIds[0],
       login_customer_id: detectedLoginCustomerId
     };
-    
     log(`Saving login_customer_id: ${detectedLoginCustomerId}`);
-    
     await fetch(updateUrl.toString(), {
       method: "PATCH",
       headers: {
@@ -387,7 +360,6 @@ serve(async (req) => {
     'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
   } as const;
 
-  // Handle CORS preflight
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
@@ -396,7 +368,6 @@ serve(async (req) => {
   log("REQ", { path: url.pathname });
 
   try {
-    // Identify current user via Supabase Auth header
     const supabaseAuth = createClient(
       SUPABASE_URL,
       ANON_KEY,
@@ -417,7 +388,6 @@ serve(async (req) => {
     const ids = await listAccessibleCustomers(access);
     log(`Found ${ids.length} accessible customer accounts: ${ids.join(', ')}`);
     
-    // Prefer saved login_customer_id for better names; do not force a global MCC
     const preferredMcc = tokenData.login_customer_id || Deno.env.get("FORCED_MCC_LOGIN_ID") || undefined;
     
     log("Step 4: Upserting customers with detailed account information...");


### PR DESCRIPTION
This PR delivers a reliability-first Google Ads integration with 1-click UX and ad-blocker resilience.

Highlights
- OAuth + account sync
  - Neutral Edge Functions to avoid ad-blockers: ga-sync-accounts, ga-ingest (fallback to google-ads-*).
  - Lists ALL non-manager accounts the user administers.
  - Uses listAccessibleCustomers + GAQL to fetch details; expands via FORCED_MCC_LOGIN_ID=2478435835 when names are generic.
- Ingestion reliability with Basic token
  - Validates hierarchy with MCC; if invalid and ALLOW_FALLBACK_NO_MCC=true, omits login-customer-id to query child directly when user has access.
  - Ingests last 30 days by default in UI (can adjust).
  - Campaigns upsert during ingest so CampaignTable shows data immediately.
- Secure storage and linking
  - Uses RLS-protected tables and SECURITY DEFINER RPCs (list_ads_accounts, link_ads_account, unlink_ads_account).
  - Connection modal supports prefill and linking/unlinking.
- Adapter normalization
  - normalizePlatform: google_ads/meta_ads -> google/meta;
  - normalizeStatus mapping for dashboard filters.
- DX & UX
  - Per-row loading spinners (no global spinner).
  - Better error toasts; guides user when ad-blocker blocks requests.

Functions
- supabase/functions/ga-sync-accounts: neutral name, same logic as google-ads-sync-accounts; cleansed of prior merge markers.
- supabase/functions/ga-ingest: neutral name, same logic as google-ads-ingest; campaign upsert included.

Environment
- Requires envs: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY, GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET, GOOGLE_ADS_DEVELOPER_TOKEN, METRICUS_INGEST_KEY, FORCED_MCC_LOGIN_ID=2478435835, ALLOW_FALLBACK_NO_MCC=true.

Post-merge steps
- Deploy Edge Functions: ga-sync-accounts, ga-ingest, ingest-metrics, ingest-campaigns.
- Verify SECURITY DEFINER RPCs exist and sanitize customer_id digits.

After deploy, re-run "Carregar dados" per linked account to populate metrics and campaigns.